### PR TITLE
remove amplify import in main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import App from './App.vue';
-import { Amplify, Auth } from 'aws-amplify';
 
 Vue.config.productionTip = false;
 


### PR DESCRIPTION
Remove amplify import after removing `aws-amplify` from the project. 